### PR TITLE
Major refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ set(GAME_SRC
   Classes/AbstractSprite.cpp
   Classes/Paddle.cpp
   Classes/Obstacle.cpp
+  Classes/Globals.cpp
   ${PLATFORM_SPECIFIC_SRC}
 )
 
@@ -139,6 +140,7 @@ set(GAME_HEADERS
   Classes/AbstractSprite.h
   Classes/Paddle.h
   Classes/Obstacle.h
+  Classes/Globals.h
   ${PLATFORM_SPECIFIC_HEADERS}
 )
 

--- a/Classes/AbstractSprite.cpp
+++ b/Classes/AbstractSprite.cpp
@@ -1,64 +1,64 @@
 #include "AbstractSprite.h"
 USING_NS_CC;
 
-AbstractSprite::AbstractSprite(Size windowSize, std::string spritePath)
+AbstractSprite::AbstractSprite(std::string spritePath)
 {
-    sprite = Sprite::create(spritePath);
-    sprite->setScale(0.2);
+    sprite_ = Sprite::create(spritePath);
+    sprite_->setScale(0.2);
 
-    Rect box = sprite->getBoundingBox();
-    width = box.getMaxX() - box.getMinX();
-    halvedWidth = box.getMaxX() - box.getMidX();
-    height = box.getMaxY() - box.getMinY();
-    halvedHeight = box.getMaxY() - box.getMidY();
+    Rect box = sprite_->getBoundingBox();
+    width_ = box.getMaxX() - box.getMinX();
+    halvedWidth_ = box.getMaxX() - box.getMidX();
+    height_ = box.getMaxY() - box.getMinY();
+    halvedHeight_ = box.getMaxY() - box.getMidY();
 }
 
 AbstractSprite::~AbstractSprite()
 {
-    delete sprite;
+    delete sprite_;
 }
 
 Sprite* AbstractSprite::getSprite() const
 {
-    return sprite;
+    return sprite_;
 }
 
 float AbstractSprite::getHeight() const
 {
-    return height;
-}
-
-float AbstractSprite::getWidth() const
-{
-    return width;
+    return height_;
 }
 
 float AbstractSprite::getHalvedHeight() const
 {
-    return halvedHeight;
+    return halvedHeight_;
+}
+
+float AbstractSprite::getWidth() const
+{
+    return width_;
 }
 
 float AbstractSprite::getHalvedWidth() const
 {
-    return halvedWidth;
+    return halvedWidth_;
 }
 
 float AbstractSprite::getX() const
 {
-    return sprite->getPosition().x;
+    return sprite_->getPosition().x;
 }
 
 float AbstractSprite::getY() const
 {
-    return sprite->getPosition().y;
-}
-
-void AbstractSprite::setPosition(Vec2 newPos)
-{
-    sprite->setPosition(newPos);
+    return sprite_->getPosition().y;
 }
 
 Vec2 AbstractSprite::getPosition() const
 {
-    return sprite->getPosition();
+    return sprite_->getPosition();
+}
+
+void AbstractSprite::setPosition(Vec2 newPos)
+{
+    sprite_->setPosition(newPos);
 }

--- a/Classes/AbstractSprite.h
+++ b/Classes/AbstractSprite.h
@@ -5,13 +5,8 @@
 
 class AbstractSprite
 {
-private:
-    cocos2d::Sprite *sprite;
-
-    float width, height, halvedWidth, halvedHeight;
-
 public:
-    AbstractSprite(cocos2d::Size windowSize, std::string spritePath);
+    AbstractSprite(std::string spritePath);
 
     virtual ~AbstractSprite();
 
@@ -32,5 +27,11 @@ public:
     cocos2d::Vec2 getPosition() const;
 
     virtual void setPosition(cocos2d::Vec2 newPos);
+
+private:
+    cocos2d::Sprite *sprite_;
+
+    float width_, height_, halvedWidth_, halvedHeight_;
+
 };
 #endif // __ABSTRACT_SPRITE_H__

--- a/Classes/Ball.cpp
+++ b/Classes/Ball.cpp
@@ -1,17 +1,19 @@
 #include "Ball.h"
 #include "AbstractSprite.h"
+#include "Globals.h"
 
 USING_NS_CC;
 
-Ball::Ball(Size windowSize)
-: AbstractSprite::AbstractSprite(windowSize, "ball.png")
+Ball::Ball()
+: AbstractSprite::AbstractSprite("ball.png")
 {
-    maxLeft = windowSize.width / 3;
-    maxRight = 2 * maxLeft;
+    Size windowSize = Globals::screenSize;
+    maxLeft_ = windowSize.width / 3;
+    maxRight_ = 2 * maxLeft_;
     setPosition(Vec2(windowSize.width / 2, windowSize.height / 15));
 
-    centered = true;
-    centerPos = getX();
+    isCentered_ = true;
+    centerPos_ = getX();
 }
 
 Ball::~Ball()
@@ -19,38 +21,38 @@ Ball::~Ball()
 
 }
 
-bool Ball::isCentered() const
-{
-    return centered;
-}
-
 void Ball::moveLeft()
 {
-    centered = false;
+    isCentered_ = false;
     Vec2 pos = getPosition();
     pos.x -= 10;
-    if(pos.x > maxLeft)
+    if(pos.x > maxLeft_)
         setPosition(pos);
 }
 
 void Ball::moveRight()
 {
-    centered = false;
+    isCentered_ = false;
     Vec2 pos = getPosition();
     pos.x += 10;
-    if(pos.x < maxRight)
+    if(pos.x < maxRight_)
         setPosition(pos);
 }
 
 void Ball::moveToCenter()
 {
     Vec2 pos = getPosition();
-    if(pos.x > centerPos)
+    if(pos.x > centerPos_)
         pos.x -= 10;
     else
-        if(pos.x < centerPos)
+        if(pos.x < centerPos_)
             pos.x += 10;
         else
-            centered = true;
+            isCentered_ = true;
     setPosition(pos);
+}
+
+bool Ball::isCentered() const
+{
+    return isCentered_;
 }

--- a/Classes/Ball.h
+++ b/Classes/Ball.h
@@ -7,13 +7,8 @@
 
 class Ball : public AbstractSprite
 {
-private:
-    float maxRight, maxLeft, centerPos;
-
-    bool centered;
-
 public:
-    Ball(cocos2d::Size windowSize);
+    Ball();
 
     virtual ~Ball();
 
@@ -24,5 +19,10 @@ public:
     virtual void moveToCenter();
 
     bool isCentered() const;
+
+private:
+    float maxRight_, maxLeft_, centerPos_;
+
+    bool isCentered_;
 };
 #endif // __BALL_H__

--- a/Classes/Globals.cpp
+++ b/Classes/Globals.cpp
@@ -1,0 +1,18 @@
+#include "Globals.h"
+#include "AbstractSprite.h"
+
+USING_NS_CC;
+
+Size Globals::screenSize = Director::getInstance()->getVisibleSize();
+float Globals::paddleY = 0.0f;
+float Globals::paddleHeight = 0.0f;
+float Globals::paddleHalvedHeight = 0.0f;
+
+void Globals::init()
+{
+    screenSize = Director::getInstance()->getVisibleSize();
+    AbstractSprite *paddle = new AbstractSprite("paddle.png");
+    paddleHeight = paddle->getHeight();
+    paddleHalvedHeight = paddle->getHalvedHeight();
+    paddleY = paddle->getY();
+}

--- a/Classes/Globals.h
+++ b/Classes/Globals.h
@@ -1,0 +1,14 @@
+#ifndef __GLOBALS_H__
+#define __GLOBALS_H__
+
+#include "cocos2d.h"
+
+class Globals
+{
+public:
+    static void init();
+    static cocos2d::Size screenSize;
+    static float paddleHeight, paddleHalvedHeight, paddleY;
+};
+
+#endif // __GLOBALS_H__

--- a/Classes/MainScene.cpp
+++ b/Classes/MainScene.cpp
@@ -1,7 +1,9 @@
 #include "MainScene.h"
 #include "SimpleAudioEngine.h"
+#include "Globals.h"
 #include <iostream>
 #include <cstdlib>
+#include <string>
 
 USING_NS_CC;
 
@@ -14,18 +16,18 @@ void MainScene::addObstacle(Obstacle* obstacle)
     }
 }
 
-void MainScene::createSprites(Size visibleSize)
+void MainScene::createSprites()
 {
-    ball = new Ball(visibleSize);
+    ball = new Ball();
     moveRight = moveLeft = false;
     this->addChild(ball->getSprite());
 
 
-    first = new Obstacle(visibleSize, Obstacle::NO_MIDDLE);
+    first = new Obstacle(Obstacle::NO_MIDDLE);
     this->addObstacle(first);
-    second = new Obstacle(visibleSize, Obstacle::NO_LEFT);
+    second = new Obstacle(Obstacle::NO_LEFT);
     this->addObstacle(second);
-    third = new Obstacle(visibleSize, Obstacle::NO_RIGHT);
+    third = new Obstacle(Obstacle::NO_RIGHT);
     this->addObstacle(third);
 }
 
@@ -70,11 +72,10 @@ void MainScene::handleObstacleMovement()
         first->update();
     else
     {
-        auto visibleSize = Director::getInstance()->getVisibleSize();
         delete first;
         first = second;
         second = third;
-        third = new Obstacle(visibleSize, rand() % 6);
+        third = new Obstacle(rand() % 6);
         this->addObstacle(third);
     }
 }
@@ -107,15 +108,16 @@ bool MainScene::init()
     auto visibleSize = Director::getInstance()->getVisibleSize();
     Vec2 origin = Director::getInstance()->getVisibleOrigin();
 
+    Globals::init();
 
     middleLine = visibleSize.height / 2;
     bottomLine = 0.0f;
 
-    createSprites(visibleSize);
+    createSprites();
 
     setEventListeners();
 
-    this->label = Label::createWithTTF("", "fonts/arial.ttf", 24);
+    this->label = Label::createWithTTF(std::to_string(Globals::screenSize.height), "fonts/arial.ttf", 24);
 
     // position the label on the center of the screen
     label->setPosition(Vec2(origin.x + visibleSize.width / 2,

--- a/Classes/MainScene.h
+++ b/Classes/MainScene.h
@@ -9,6 +9,16 @@
 
 class MainScene : public cocos2d::Layer
 {
+public:
+    static cocos2d::Scene* createScene();
+
+    virtual bool init();
+
+    virtual void update(float delta);
+
+    // implement the "static create()" method manually
+    CREATE_FUNC(MainScene);
+
 private:
     Ball *ball;
 
@@ -22,7 +32,7 @@ private:
 
     cocos2d::Label *label;
 
-    void createSprites(cocos2d::Size visibleSize);
+    void createSprites();
 
     void addObstacle(Obstacle* obstacle);
 
@@ -32,20 +42,9 @@ private:
 
     void handleObstacleMovement();
 
-public:
-    static cocos2d::Scene* createScene();
+    void onKeyPressed(cocos2d::EventKeyboard::KeyCode keyCode, cocos2d::Event* event);
 
-    virtual bool init();
-
-    virtual void update(float delta);
-
-    // implement the "static create()" method manually
-    CREATE_FUNC(MainScene);
-
-    virtual void onKeyPressed(cocos2d::EventKeyboard::KeyCode keyCode, cocos2d::Event* event);
-
-    virtual void onKeyReleased(cocos2d::EventKeyboard::KeyCode keyCode, cocos2d::Event* event);
-
+    void onKeyReleased(cocos2d::EventKeyboard::KeyCode keyCode, cocos2d::Event* event);
 };
 
 #endif // __HELLOWORLD_SCENE_H__

--- a/Classes/Obstacle.cpp
+++ b/Classes/Obstacle.cpp
@@ -1,12 +1,13 @@
 #include "Obstacle.h"
 #include "Paddle.h"
+#include "Globals.h"
 
-Obstacle::Obstacle(cocos2d::Size windowSize, int type)
+Obstacle::Obstacle(int type)
 {
-    AbstractSprite *absSpr = new AbstractSprite(windowSize, "paddle.png");
+    AbstractSprite *absSpr = new AbstractSprite("paddle.png");
     height = absSpr->getHeight();
     halvedHeight = absSpr->getHalvedHeight();
-    y = windowSize.height + halvedHeight;
+    y = Globals::screenSize.height + halvedHeight;
 
     switch(type)
     {
@@ -16,35 +17,35 @@ Obstacle::Obstacle(cocos2d::Size windowSize, int type)
         }
         case LEFT:
         {
-            paddles.push_back(new Paddle(windowSize, Paddle::LEFT));
+            paddles.push_back(new Paddle(Paddle::LEFT));
             break;
         }
         case MIDDLE:
         {
-            paddles.push_back(new Paddle(windowSize, Paddle::MIDDLE));
+            paddles.push_back(new Paddle(Paddle::MIDDLE));
             break;
         }
         case RIGHT:
         {
-            paddles.push_back(new Paddle(windowSize, Paddle::RIGHT));
+            paddles.push_back(new Paddle(Paddle::RIGHT));
             break;
         }
         case NO_LEFT:
         {
-            paddles.push_back(new Paddle(windowSize, Paddle::MIDDLE));
-            paddles.push_back(new Paddle(windowSize, Paddle::RIGHT));
+            paddles.push_back(new Paddle(Paddle::MIDDLE));
+            paddles.push_back(new Paddle(Paddle::RIGHT));
             break;
         }
         case NO_MIDDLE:
         {
-            paddles.push_back(new Paddle(windowSize, Paddle::LEFT));
-            paddles.push_back(new Paddle(windowSize, Paddle::RIGHT));
+            paddles.push_back(new Paddle(Paddle::LEFT));
+            paddles.push_back(new Paddle(Paddle::RIGHT));
             break;
         }
         case NO_RIGHT:
         {
-            paddles.push_back(new Paddle(windowSize, Paddle::LEFT));
-            paddles.push_back(new Paddle(windowSize, Paddle::MIDDLE));
+            paddles.push_back(new Paddle(Paddle::LEFT));
+            paddles.push_back(new Paddle(Paddle::MIDDLE));
             break;
         }
     };

--- a/Classes/Obstacle.h
+++ b/Classes/Obstacle.h
@@ -6,16 +6,11 @@
 
 class Obstacle
 {
-private:
-    std::vector<Paddle*> paddles;
-
-    float y, height, halvedHeight;
-
 public:
     static const int NONE = 0, LEFT = 1, MIDDLE = 2, RIGHT = 3, \
                      NO_LEFT = 4, NO_MIDDLE = 5, NO_RIGHT = 6;
 
-    Obstacle(cocos2d::Size windowSize, int type);
+    Obstacle(int type);
 
     virtual ~Obstacle();
 
@@ -28,6 +23,11 @@ public:
     float getHeight() const;
 
     float getHalvedHeight() const;
+
+private:
+    std::vector<Paddle*> paddles;
+
+    float y, height, halvedHeight;
 };
 
 #endif // __OBSTACLE_H__

--- a/Classes/Paddle.cpp
+++ b/Classes/Paddle.cpp
@@ -1,10 +1,13 @@
 #include "Paddle.h"
+#include "Globals.h"
 
 USING_NS_CC;
 
-Paddle::Paddle(Size windowSize, int type)
-: AbstractSprite::AbstractSprite(windowSize, "paddle.png")
+Paddle::Paddle(int type)
+: AbstractSprite::AbstractSprite("paddle.png")
 {
+    Size windowSize = Globals::screenSize;
+
     float offscreen_y = windowSize.height + getHalvedHeight();
 
     if(type == MIDDLE)

--- a/Classes/Paddle.h
+++ b/Classes/Paddle.h
@@ -9,7 +9,7 @@ class Paddle : public AbstractSprite
 public:
     static const int LEFT = 0, MIDDLE = 1, RIGHT = 2;
 
-    Paddle(cocos2d::Size windowSize, int type);
+    Paddle(int type);
 
     virtual ~Paddle();
 


### PR DESCRIPTION
In this branch the `Globals` class was added in order to remove unnecessary constructor parameters. In addition, refactoring was done as well where `public:` members were moved before `private:` members to improve readability and private members are now followed by `_` to improve readbility and to follow C++ style guides.
